### PR TITLE
Fix layout and minor changes

### DIFF
--- a/PEPM2025-manuskript/pepm2025.tex
+++ b/PEPM2025-manuskript/pepm2025.tex
@@ -1627,18 +1627,14 @@ with the cursor at the root of the tree.
 \begin{lstlisting}[style=inline, language=elm, caption={SQL editor session in an Elm REPL}, label={lst:SQL-repl}]
 > example = Q (Select (Ident "col-a") (Ident "table-b") (Where (Greater (Eident (Ident "col-a")) (Econst (Num 2)))))
     : Base
-
 > decomposed = decompose example
 (Cctx_hole,Root_q_CLess (Select_CLess (Ident_CLess "col-a") (Ident_CLess "table-b") (Where_CLess (Greater_CLess (Eident_CLess (Ident_CLess "col-a")) (Econst_CLess (Num_CLess 2))))))
     : ( Cctx, Wellformed )
-
 > new = parent decomposed
 Nothing : Maybe ( Cctx, Wellformed )
-
 > child 1 decomposed
 Just (Select_CLess_cctx1 Cctx_hole (Ident_CLess "table-b") (Where_CLess (Greater_CLess (Eident_CLess (Ident_CLess "col-a")) (Econst_CLess (Num_CLess 2)))),Root_id_CLess (Ident_CLess "col-a"))
     : Maybe ( Cctx, Wellformed )
-
 > substitute decomposed (Q_CLess Hole_q_CLess)
 Just (Cctx_hole,Root_q_CLess Hole_q_CLess)
     : Maybe ( Cctx, Wellformed )

--- a/PEPM2025-manuskript/pepm2025.tex
+++ b/PEPM2025-manuskript/pepm2025.tex
@@ -1404,7 +1404,6 @@ and separate them into their own separate modules.
 
 \begin{example}{ex:parser-to-elm-codegen}
   Given the specification in example \cref{ex:as-sql-lang}, the parser can produce following \texttt{Declaration} for the \texttt{Q} algebraic data type in example \cref{ex:sql-data-types}:
-  \newpage
   \begin{lstlisting}[language=elm]
 Elm.customType "Q"
             [ Elm.variantWith "Select"
@@ -1550,7 +1549,6 @@ is replaced with its corresponding cursorless operator $\hat{o} \in \hat{\mathca
 The cursor context and well-formed tree pair as defined above will decompose
 any well-formed \abt into a unique pair of a cursor context and a well-formed tree.
 
-
 \subsubsection{Cursor movement - Child}
 Cursor movement is a fundamental operation, allowing the editor to move the cursor
 to a different position, changing the target of editor expressions. This is defined
@@ -1570,7 +1568,7 @@ in the well-formed tree.
 For a visualization of this, see \cref{fig:movement-example} showing the result
 of applying various \texttt{child} operations to a decomposed tree.
 
-\begin{figure}[H]
+\begin{figure}[h]
   \centering
   \begin{subfigure}[b]{0.9\linewidth}
     \centering
@@ -1621,6 +1619,8 @@ has no cursor, showing that the decomposition of the tree will result in a
 cursor context containing only the context hole and a well-formed tree
 with the cursor at the root of the tree.
 
+\vspace{2mm}
+\begin{minipage}{\linewidth}
 \begin{lstlisting}[style=inline, language=elm, caption={SQL editor session in an Elm REPL}, label={lst:SQL-repl}]
 > example = Q (Select (Ident "col-a") (Ident "table-b") (Where (Greater (Eident (Ident "col-a")) (Econst (Num 2)))))
     : Base
@@ -1640,6 +1640,8 @@ Just (Select_CLess_cctx1 Cctx_hole (Ident_CLess "table-b") (Where_CLess (Greater
 Just (Cctx_hole,Root_q_CLess Hole_q_CLess)
     : Maybe ( Cctx, Wellformed )
 \end{lstlisting}
+\end{minipage}
+\vspace{2mm}
 
 Attempting to move the cursor to the
 parent will result in \texttt{Nothing} (empty value of the \texttt{Maybe} option type in Elm),

--- a/PEPM2025-manuskript/pepm2025.tex
+++ b/PEPM2025-manuskript/pepm2025.tex
@@ -237,13 +237,13 @@ operations manipulate abstract syntax trees from an applied
 $\lambda$-calculus.
 
 A major advantage of this approach is that it is typed and that type
-systems can be provably sound: The type system of the editor calculus
+systems can be proven to be sound: The type system of the editor calculus
 will then guarantee that if an editor term $E$ is well-typed, then $E$
 will produce a well-formed program.
 
 However, existing editor calculi do not account for context-sensitive
 aspects of program syntax, and notably not the binding
-mechanisms that are prominent in abstract syntax.
+mechanisms that are prominent in higher-order abstract syntax.
 
 Moreover, the work on editor calculi has so far been dependent on the
 syntax of the programming language that the editor must
@@ -266,7 +266,10 @@ the simply-typed lambda calculus extended with pairs, booleans,
 pattern matching and fixed-points. These fragments are all known to
 have type systems with strong safety guarantees, and in this way we
 obtain a general result on type safety that applies to any instance of
-our generalized editor calculus.
+our generalized editor calculus. Finally, given the encoding, we show
+how the generalized editor calculus can be implemented in a modern
+functional language and we provide an example in the form of an editor 
+instance.
 
 \section{A Generalized Editor Calculus}\label{sec:general_editor}
 
@@ -530,7 +533,7 @@ operator, respectively.
              \hat{a} \in \ABT{}_e
             \end{array}$
     }{\caption{Selected reduction rules for substitution}\label{fig:example_substitution_rules}}
-    Notice that in every rule we ensure that the substitution can only be performed if the \abt $\hat{a}$ is of the same sort as the operator. For example, given the configuration \[ \lr{\{let\}.nil, \text{let $x = [\hole{e}]$ in $x+x$}}\] we cannot substitute in a statement, as shown below.
+    Notice that in every rule we ensure that the substitution can only be performed if the \abt $\hat{a}$ is of the same sort as the operator. For example, given the configuration \[ \lr{\{let\}.nil, \text{let $x = [\hole{e}]$ in $x+x$}}\] we cannot substitute in a statement, as shown in the following.
     \begin{center}
     \begin{tabular}{c}
         \inference[\runa{Context}]
@@ -1402,7 +1405,7 @@ well-formed trees $\dot{\mathcal{O}},\dot{\mathcal{S}}$,
 the CodeGen package can generate algebraic data types for every sort and its operators
 and separate them into their own separate modules.
 
-\begin{example}{ex:parser-to-elm-codegen}
+\begin{example}\label{ex:parser-to-elm-codegen}
   Given the specification in example \cref{ex:as-sql-lang}, the parser can produce following \texttt{Declaration} for the \texttt{Q} algebraic data type in example \cref{ex:sql-data-types}:
   \begin{lstlisting}[language=elm]
 Elm.customType "Q"
@@ -1413,7 +1416,7 @@ Elm.customType "Q"
             ]
 \end{lstlisting}
 
-  This declaration, if passed to Elm CodeGen's \texttt{File} function, would generate a source file with following contents:
+  This declaration, if passed to Elm CodeGen's \texttt{File} function, would generate a file with following contents:
   \begin{lstlisting}[language=elm]
 type Q
     = Select Id Id Clause


### PR DESCRIPTION
Link til output pdf med disse ændringer:
[pepm2025.pdf](https://github.com/user-attachments/files/17396647/pepm2025.pdf)


Synes det her er et bedre bud på layout, men:
- Listing på linje 1190-1210 er blevet tæt pakket, for at undgå den går ud over siden
- Kan vi leve med at eksempel 2.3 (linje 357-412) er splittet op?
- Samme med eksempel 3.2

Har også lavet mindre ændringer, jeg lige vil have godkendt (se commit)

- nogen forslag til at gøre listings pænere?
- er det relevant at have implementations-afsnittets afsnit om Conditionals osv? p.t. 5.4.7
- fjerne Table 1 ?
- kommentarer i https://github.com/hanshuttel/generalized-editor/pull/3



